### PR TITLE
Use unofficial 3.10 manylinux wheel from pyvista

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -48,16 +48,36 @@ jobs:
             sudo apt install -y libegl1 libegl1-mesa-dev
           fi
 
-      - name: Build wheel
+      - name: Conda Deps Setup
         shell: bash -l {0}
         run: |
           conda install -n cadquery-ocp -y ocp=7.6.* vtk=9.1.0
+
+      - name: Pip Deps Setup
+        shell: bash -l {0}
+        run: |
           pip install --upgrade pip
           pip install build setuptools wheel requests auditwheel delocate delvewheel
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            export VTK_MANYLINUX=/tmp/vtk-manylinux
-            pip install -t $VTK_MANYLINUX --no-deps vtk~=9.1.0
-          fi
+
+      - name: Manylinux Setup 1
+        shell: bash -l {0}
+        if: ${{ matrix.os == 'ubuntu-18.04' && matrix.python-version != '3.10' }}
+        run: |
+          export VTK_MANYLINUX=/tmp/vtk-manylinux
+          pip install -t $VTK_MANYLINUX --no-deps vtk~=9.1.0
+
+      # vtk 9.1 py3.10 manylinux wheel not available on PyPI.
+      # Use pyvista build: https://gitlab.kitware.com/vtk/vtk/-/issues/18335
+      - name: Manylinux Setup 2
+        shell: bash -l {0}
+        if: ${{ matrix.os == 'ubuntu-18.04' && matrix.python-version == '3.10' }}
+        run: |
+          export VTK_MANYLINUX=/tmp/vtk-manylinux
+          pip install -t $VTK_MANYLINUX --no-deps https://github.com/pyvista/pyvista-wheels/raw/main/vtk-9.1.0.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+
+      - name: Build wheel
+        shell: bash -l {0}
+        run: |
           python -m build --no-isolation --wheel
 
       - name: Print info


### PR DESCRIPTION
@jmwright There's no manylinux whee﻿l for py3.10 and vtk 9.1, but there's an unofficial one from pyvista: https://gitlab.kitware.com/vtk/vtk/-/issues/18335#note_1180656

WFM but you may have reservations about an unofficial build.
