### PR TITLE
Build wheels for 7.7.0

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Conda Deps Setup
         shell: bash -l {0}
         run: |
-          conda install -c cadquery -n cadquery-ocp -y ocp==7.6.3.alpha vtk=9.1.0
+          conda install -c cadquery -n cadquery-ocp -y ocp==7.7.0.alpha vtk=9.2.5
 
       - name: Pip Deps Setup 1
         shell: bash -l {0}
@@ -67,20 +67,10 @@ jobs:
 
       - name: Manylinux Build 1
         shell: bash -l {0}
-        if: ${{ matrix.os == 'ubuntu-20.04' && matrix.python-version != '3.10' }}
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         run: |
           export VTK_MANYLINUX=/tmp/vtk-manylinux
-          pip install -t $VTK_MANYLINUX --no-deps vtk~=9.1.0
-          python -m build --no-isolation --wheel
-
-      # vtk 9.1 py3.10 manylinux wheel not available on PyPI.
-      # Use pyvista build: https://gitlab.kitware.com/vtk/vtk/-/issues/18335
-      - name: Manylinux Build 2
-        shell: bash -l {0}
-        if: ${{ matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.10' }}
-        run: |
-          export VTK_MANYLINUX=/tmp/vtk-manylinux
-          pip install -t $VTK_MANYLINUX --no-deps https://github.com/pyvista/pyvista-wheels/raw/main/vtk-9.1.0.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+          pip install -t $VTK_MANYLINUX --no-deps vtk~=9.2.0
           python -m build --no-isolation --wheel
 
       - name: Conda-only Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,6 @@ jobs:
           mkdir dist
           mv wheels/**/*.whl dist
           rm -rf wheels
-          # use this if the versions in the file names need to be changed for PyPi
-          cd dist
-          for f in *7.6.3.0*; do [ -f "$f" ] && mv -- "$f" "${f/7.6.3.0/7.6.3}"; done
-          cd ..
-          # END use this if the versions in the file names need to be changed for PyPi
           ls dist
 
       # see https://github.com/marketplace/actions/create-release

--- a/setup.py
+++ b/setup.py
@@ -355,9 +355,20 @@ conda_prefix = info["active_prefix"] or info["conda_prefix"]
 args = [conda, "list", "--json", "^ocp$"]
 [ocp_meta] = json.loads(subprocess.check_output(args))
 
+# Massage conda version string, e.g. "7.6.3.0", "7.6.3.alpha" into a
+# wheel version string.  setuptools already converts "X.Y.Z.alpha" to
+# "X.Y.Za0".  For now, just replace "X.Y.Z.0" with "X.Y.Z".
+wheel_version = ocp_meta["version"]
+while wheel_version.count(".") > 2 and wheel_version.endswith(".0"):
+    wheel_version = wheel_version[:-2]
+
+# # Release an alpha wheel as a non-alpha wheel
+# if wheel_version == "7.7.0.alpha":
+#     wheel_version = "7.7.0"
+
 setup(
     name="cadquery-ocp",
-    version=ocp_meta["version"],
+    version=wheel_version,
     description="OCP+VTK wheel with shared library dependencies bundled.",
     long_description=open("README.md").read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Match latest versions of `ocp` and `vtk` conda packages.

VTK manylinux wheels are now available on PyPI for
3.10, so remove use of third-party wheel.
