### PR TITLE
Add a `local-build.sh` script to build Apple Silicon wheels locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ This repository is used to build wheels for OCP, which is CadQuery's bindings to
 * Releases
 
 The Build workflow is triggered manually by a developer, and sets up conda environments for each of the wheels to be built, builds the wheels, and then uploads them as artifacts to the GitHub Action. The Releases workflow is run when a tag is created, and takes the wheels attached to the latest build and uploads them to PyPi. Each time a new version of OCP is released these Actions, along with the setup.py file, need to be modified to build and release the new version.
+
+# Building for Apple Silicon locally
+
+Since there are no free Apple Silicon runners available for GitHub actions, a simple solution is to just run the build locally on an Apple Silicon Macbook. To that end, this repo contains a `local-build.sh` script which builds for whatever architecture the local machine is running on. On an M1 Macbook Pro it should take approx 25 minutes to build for all 4 Python versions.

--- a/local-build.sh
+++ b/local-build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+function info() {
+  echo -e "\033[1;36m$1\033[0m"
+}
+
+trap "info Exited!; exit;" SIGINT SIGTERM
+
+for python_version in '3.8' '3.9' '3.10' '3.11'
+do
+    info "Building wheel for Python $python_version..."
+    info "Removing temp files..."
+    rm -rf -v ./build
+    rm -rf -v ./cadquery_ocp.egg-info
+    info "Conda Deps Setup..."
+    conda create --yes -n ocp-build-system -c cadquery -c conda-forge \
+        python=$python_version \
+        ocp=7.7.1.* \
+        vtk=9.2.* \
+        pip
+    info "Pip Deps Setup..."
+    conda run -n ocp-build-system pip install \
+        build \
+        setuptools \
+        wheel \
+        requests \
+        delocate \
+        delvewheel
+    info "Conda-only Build..."
+    conda run --live-stream -n ocp-build-system \
+        python -m build --no-isolation --wheel
+done


### PR DESCRIPTION
Since there are no free Apple Silicon runners available for GitHub actions, a simple solution is to just run the build locally on an Apple Silicon Macbook. 

To that end, this PR adds a `local-build.sh` script that builds for whatever architecture the local machine is running on. On an M1 Macbook Pro it should take approx 25 minutes to build for all 4 Python versions.

Then the wheels can be uploaded manually to the release, or we can develop a `local-release.sh` script to add the wheels to an existing release.