### PR TITLE
Workflow for MacOS arm64 build with new GH runners

### DIFF
--- a/.github/workflows/local-build.yml
+++ b/.github/workflows/local-build.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os: [ 'macos-14' ]  #[ 'ubuntu-22.04', 'macos-11', 'macos-14', 'windows-2019' ]
         # python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: ["3.10"]
 
     steps:
 
@@ -116,8 +117,9 @@ jobs:
         shell: bash -l {0}
         run: |
           conda deactivate
-          conda create --yes -n cadquerytest python=${{ matrix.python-version }}
+          CONDA_SUBDIR=osx-arm64 conda create --yes -n cadquerytest python=3.10
           conda activate cadquerytest
+          conda config --env --set subdir osx-arm64
           python -m pip install dist/*.whl
           python -c "import OCP;print('OCP imported successfully')"
 

--- a/.github/workflows/local-build.yml
+++ b/.github/workflows/local-build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ 'macos-14' ]  #[ 'ubuntu-22.04', 'macos-11', 'macos-14', 'windows-2019' ]
         # python-version: [ '3.9', '3.10', '3.11', '3.12' ]
-        python-version: ["3.10"]
+        python-version: [ '3.10' ]
 
     steps:
 
@@ -118,8 +118,8 @@ jobs:
         run: |
           conda deactivate
           CONDA_SUBDIR=osx-arm64 conda create --yes -n cadquerytest python=3.10
+          conda run -n cadquerytest conda config --env --set subdir osx-arm64
           conda activate cadquerytest
-          conda config --env --set subdir osx-arm64
           python -m pip install dist/*.whl
           python -c "import OCP;print('OCP imported successfully')"
 

--- a/local-build.sh
+++ b/local-build.sh
@@ -20,7 +20,7 @@ do
         vtk=9.2.* \
         pip
     info "Conda Arch Setup..."
-    conda run -n ocp-build-system config --env --set subdir osx-arm64
+    conda run -n ocp-build-system conda config --env --set subdir osx-arm64
     info "Pip Deps Setup..."
     conda run -n ocp-build-system pip install \
         build \

--- a/local-build.sh
+++ b/local-build.sh
@@ -14,11 +14,13 @@ do
     rm -rf -v ./build
     rm -rf -v ./cadquery_ocp.egg-info
     info "Conda Deps Setup..."
-    conda create --yes -n ocp-build-system -c cadquery -c conda-forge \
+    CONDA_SUBDIR=osx-arm64 conda create --yes -n ocp-build-system -c cadquery -c conda-forge \
         python=$python_version \
         ocp=7.7.2.* \
         vtk=9.2.* \
         pip
+    info "Conda Arch Setup..."
+    conda run -n ocp-build-system config --env --set subdir osx-arm64
     info "Pip Deps Setup..."
     conda run -n ocp-build-system pip install \
         build \


### PR DESCRIPTION
Not perfect, but everything works. As I mentioned on the issue the main issue was that conda seems to default to `osx-64` rather than `osx-arm64`. Known issues are: there are some spurious and seemingly unnecessary steps in the action file, and also the artifact generated at the end has an incorrect filename.

Also, the matrix version of python is not setup very well in this PR.