### PR TITLE
Eliminate delvewheel mangling and simplify try_unmangle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -248,6 +248,8 @@ def repair_wheel_windows(lib_path, whl, out_dir):
         "-m",
         "delvewheel",
         "repair",
+        "-vv",
+        "--no-mangle-all",
         f"--wheel-dir={out_dir}",
         whl,
     ]
@@ -346,10 +348,6 @@ def write_licenses(prefix, whl, always_pkgs, added_files, out):
 
 
 def try_unmangle(n):
-    # delvewheel mangling example: "vtkCommonColor-9.0.dll" => "vtkCommonColor-9.0-87ee4902.dll"
-    m = re.match("^(.+)-[0-9A-Fa-f]{8,}([.]dll)$", n)
-    if m:
-        return m.group(1) + m.group(2)
     # auditwheel mangling example: "libvtkCommonColor-9.0.so.9.0.1" => "libvtkCommonColor-9-9810eeb7.0.so.9.0.1"
     m = re.match("^([^.]+)-[0-9A-Fa-f]{8,}([.].+)$", n)
     if m:


### PR DESCRIPTION
We have been working on a new package called ocp-addons which is intended to provide separate performance-critical code in C++ and built with pybind11 against OCP libs. We are able to compile wheels and use them on Linux/MacOS without issue. We are able to compile a wheel on Windows and use it with the ocp package from conda-forge, but have had some very confusing issues with the cadquery-ocp. Basically the mangling process from delvewheel seems to introduce something that looks like an ABI/DLL incompatibility. The fix is to simply pass the --no-mangle-all to delvewheel during the repair process and the OCCT libs will be copied like e.g. TKBRep.dll rather than with mangled names. Something about delvewheel is actually modifying the SHA256 sum of the DLLs it mangles.

There is also some redundant/non-working code for in setup.py of the above repo for windows wheel unmangling that is eliminated here.