### PR TITLE
Working VTK build environments for py 39 through py 312 and Linux, MacOS-13, MacOS-14, Windows

### DIFF
--- a/.github/workflows/build-vtk.yml
+++ b/.github/workflows/build-vtk.yml
@@ -30,37 +30,68 @@ jobs:
         shell: bash -l {0}
         # The `bdist_wheel` command requires the `wheel` package
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --upgrade wheel
-          python3 -m pip freeze
-
+          python -V
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade wheel
+          python -m pip freeze
+          
+      - name: Setup Windows build environment (MSVC)
+        if: ${{ matrix.os == 'windows-2019' }}
+        uses: ilammy/msvc-dev-cmd@v1
+        
       - name: Ubuntu Deps
         shell: bash -l {0}
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt install -y build-essential cmake mesa-common-dev mesa-utils freeglut3-dev python3-dev python3-venv git-core ninja-build cmake wget libglvnd0 libglvnd-dev
-          fi
+          sudo apt install -y build-essential cmake mesa-common-dev mesa-utils freeglut3-dev python3-dev python3-venv git-core ninja-build cmake wget libglvnd0 libglvnd-dev
+      
+      # - name: MacOS-11 Deps 
+      #   shell: bash -l {0}
+      #   if: ${{ matrix.os != 'macos-11' }}
+      #   run: |
 
-      - name: Windows Deps
+      - name: MacOS-14 Deps 
         shell: bash -l {0}
+        if: ${{ matrix.os != 'macos-14' }}
         run: |
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            choco install ninja
-          fi
+          brew install ninja
 
-      - name: Build Wheel from Scratch
+      # - name: Windows Deps
+      #   shell: bash -l {0} #cmd?
+      #   if: ${{ matrix.os != 'windows-2019' }}
+      #   run: |
+
+      - name: Build Wheel from Scratch (non-windows)
         shell: bash -l {0}
+        if: ${{ matrix.os != 'windows-2019' }}
         run: |
-          pip3 install --upgrade setuptools
+          python -V
+          pip install --upgrade setuptools
           mkdir -p ./vtk/build
           curl -L -O https://www.vtk.org/files/release/9.2/VTK-9.2.6.tar.gz  # Update this for newer releases of VTK
           tar -zxf VTK-9.2.6.tar.gz --directory ./vtk/
           cd ./vtk/build
           cmake -GNinja -DVTK_WHEEL_BUILD=ON -DVTK_WRAP_PYTHON=ON -DCMAKE_BUILD_TYPE=Release ../VTK-9.2.6
           ninja
-          python3 setup.py bdist_wheel
+          python setup.py bdist_wheel
           cd ../../
           find ./ -iname *.whl
+
+      - name: Build Windows Wheel from Scratch
+        shell: cmd
+        if: ${{ matrix.os == 'windows-2019' }}
+        run: |
+          cl
+          pip install --upgrade setuptools
+          mkdir vtk\build
+          curl -L -O https://www.vtk.org/files/release/9.2/VTK-9.2.6.tar.gz
+          tar -zxf VTK-9.2.6.tar.gz --directory vtk\
+          cd vtk\build
+          cmake -GNinja -DVTK_WHEEL_BUILD=ON -DVTK_WRAP_PYTHON=ON -DCMAKE_BUILD_TYPE=Release ..\VTK-9.2.6
+          ninja
+          python setup.py bdist_wheel
+          cd ..\..\
+          dir /s
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-vtk.yml
+++ b/.github/workflows/build-vtk.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup Python Env
-        shell: bash -l {0}
+        # shell: bash -l {0}
         # The `bdist_wheel` command requires the `wheel` package
         run: |
           python -V
@@ -79,6 +79,7 @@ jobs:
         shell: cmd
         if: ${{ runner.os == 'Windows' }}
         run: |
+          python -V
           cl
           pip install --upgrade setuptools
           mkdir vtk\build

--- a/.github/workflows/build-vtk.yml
+++ b/.github/workflows/build-vtk.yml
@@ -21,8 +21,17 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
+        if: ${{ runner.os != 'macOS' }} # setup-python is currently very broken for macos-14 and possibly 13 too
         with:
           python-version: ${{ matrix.python-version }}
+          
+      - name: Setup Micromamba on MacOS
+        if: ${{ runner.os == 'macOS' }} # setup-python is currently very broken for macos-14 and possibly 13 too
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: build-vtk # required by micromamba
+          create-args: >-
+            python=${{ matrix.python-version }}
 
       - name: Setup Python Env
         # shell: bash -l {0}
@@ -53,16 +62,34 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: |
           brew install ninja
+          micromamba info
 
       # - name: Windows Deps
       #   shell: bash -l {0} #cmd?
       #   if: ${{ matrix.os != 'windows-2019' }}
       #   run: |
 
-      - name: Build Wheel from Scratch (non-windows)
+      - name: Build Linux Wheel from Scratch
         shell: bash -l {0}
-        if: ${{ runner.os != 'Windows' }}
+        if: ${{ runner.os == 'Linux' }}
         run: |
+          python -V
+          pip install --upgrade setuptools
+          mkdir -p ./vtk/build
+          curl -L -O https://www.vtk.org/files/release/9.2/VTK-9.2.6.tar.gz  # Update this for newer releases of VTK
+          tar -zxf VTK-9.2.6.tar.gz --directory ./vtk/
+          cd ./vtk/build
+          cmake -GNinja -DVTK_WHEEL_BUILD=ON -DVTK_WRAP_PYTHON=ON -DCMAKE_BUILD_TYPE=Release ../VTK-9.2.6
+          ninja
+          python setup.py bdist_wheel
+          cd ../../
+          find ./ -iname *.whl
+
+      - name: Build macOS Wheel from Scratch
+        shell: bash -l {0}
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          micromamba info
           python -V
           pip install --upgrade setuptools
           mkdir -p ./vtk/build

--- a/.github/workflows/build-vtk.yml
+++ b/.github/workflows/build-vtk.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -36,12 +36,12 @@ jobs:
           python -m pip freeze
           
       - name: Setup Windows build environment (MSVC)
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ runner.os == 'Windows' }}
         uses: ilammy/msvc-dev-cmd@v1
         
       - name: Ubuntu Deps
         shell: bash -l {0}
-        if: ${{ matrix.os != 'ubuntu-20.04' }}
+        if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt install -y build-essential cmake mesa-common-dev mesa-utils freeglut3-dev python3-dev python3-venv git-core ninja-build cmake wget libglvnd0 libglvnd-dev
       
@@ -52,7 +52,7 @@ jobs:
 
       - name: MacOS-14 Deps 
         shell: bash -l {0}
-        if: ${{ matrix.os != 'macos-14' }}
+        if: ${{ runner.os == 'macOS' }}
         run: |
           brew install ninja
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build Wheel from Scratch (non-windows)
         shell: bash -l {0}
-        if: ${{ matrix.os != 'windows-2019' }}
+        if: ${{ runner.os != 'Windows' }}
         run: |
           python -V
           pip install --upgrade setuptools
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build Windows Wheel from Scratch
         shell: cmd
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ runner.os == 'Windows' }}
         run: |
           cl
           pip install --upgrade setuptools

--- a/.github/workflows/build-vtk.yml
+++ b/.github/workflows/build-vtk.yml
@@ -13,10 +13,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ 'ubuntu-20.04', 'macos-11', 'macos-14', 'windows-2019' ]
-        # os: [ 'ubuntu-20.04', 'macos-11', 'macos-14', 'windows-2019' ]
-        python-version: [ '3.11' ]
-        # python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        os: [ 'ubuntu-20.04', 'macos-13', 'macos-14', 'windows-2019' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
       - name: Checkout project
@@ -45,12 +43,12 @@ jobs:
         run: |
           sudo apt install -y build-essential cmake mesa-common-dev mesa-utils freeglut3-dev python3-dev python3-venv git-core ninja-build cmake wget libglvnd0 libglvnd-dev
       
-      # - name: MacOS-11 Deps 
+      # - name: MacOS-13 Deps 
       #   shell: bash -l {0}
       #   if: ${{ matrix.os != 'macos-11' }}
       #   run: |
 
-      - name: MacOS-14 Deps 
+      - name: MacOS Deps # 13 and 14
         shell: bash -l {0}
         if: ${{ runner.os == 'macOS' }}
         run: |


### PR DESCRIPTION
I had to fall back to using micromamba (only for macos-13 and macos-14) to ensure that the correct python version is used for the build. There is a problem with actions/setup-python with MacOS runners where it does not correctly override the sys-bundled python.

Getting MSVC working properly was also a bit of a chore and necessitated switching off of bash for Windows. I am using cmd.exe but it may also be possible to switch to powershell.

As usual, I found that having separate sections for each OS was needed.