### PR TITLE
Strip OCP .so in linux wheel builds.

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -74,6 +74,13 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -c cadquery -n cadquery-ocp -y ocp=7.7.2.* vtk=9.2.* occt=7.7.2=all* auditwheel
+          # Save ~100MiB in shared object size by stripping debugging symbols.
+          # See https://github.com/CadQuery/ocp-build-system/issues/33 for details.
+          echo "Before stripping:"
+          ls -l ~/conda_pkgs_dir/ocp-*/lib/python*/site-packages/OCP*.so /usr/share/miniconda3/envs/cadquery-ocp/lib/python*/site-packages/OCP*.so
+          strip ~/conda_pkgs_dir/ocp-*/lib/python*/site-packages/OCP*.so /usr/share/miniconda3/envs/cadquery-ocp/lib/python*/site-packages/OCP*.so
+          echo "After stripping:"
+          ls -l ~/conda_pkgs_dir/ocp-*/lib/python*/site-packages/OCP*.so /usr/share/miniconda3/envs/cadquery-ocp/lib/python*/site-packages/OCP*.so
 
       - name: Pip Deps Setup 1
         shell: bash -l {0}


### PR DESCRIPTION
Addresses https://github.com/CadQuery/ocp-build-system/issues/33.

Test run in https://github.com/fischman/ocp-build-system/actions/runs/10912189440 has  generated artifacts (linux wheels) showing the smaller OCP .so.