### PR TITLE
Fixes for all three `pyproject.toml` files

### DIFF
--- a/cadquery_vtk/pyproject.toml
+++ b/cadquery_vtk/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.9"
 description = "This is a custom build of the VTK Python wheels which are specific to the needs of the CadQuery project."
 readme = "README.md"
 license = "BSD-3-Clause"
-keywords = ["VTK", OpenCASCADE]
+keywords = ["VTK", "OpenCASCADE"]
 classifiers = [
   "Programming Language :: Python"
 ]

--- a/pypi-stubs/README.md
+++ b/pypi-stubs/README.md
@@ -1,0 +1,7 @@
+# cadquery-ocp-stubs
+
+Typing stubs for [cadquery-ocp](https://pypi.org/project/cadquery-ocp/) automaticaly generated using [pybind11-stubgen](https://github.com/CadQuery/pybind11-stubgen).
+
+## Notes
+
+In order to use them with MyPy install using pip

--- a/pypi-stubs/pyproject.toml
+++ b/pypi-stubs/pyproject.toml
@@ -5,9 +5,10 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "cadquery-ocp-stubs"
 version = "7.8.1.1"
-description = "API stubs for cadquery-ocp"
+description = "Typing stubs for cadquery-ocp automaticaly generated using pybind11-stubgen."
 authors = [{ name = "Bernhard Walter", email = "b_walter@arcor.de" }]
 requires-python = ">=3.10"
+readme = "README.md"
 
 [tool.setuptools]
 package-dir = {"cadquery_ocp_stubs" = "OCP-stubs"}

--- a/pypi/README.md
+++ b/pypi/README.md
@@ -1,0 +1,12 @@
+# cadquery-ocp (also known as OCP)
+
+Python wrapper for OCCT generated using pywrap. Typing stubs available [here](https://github.com/CadQuery/OCP-stubs).
+
+## Goals
+* Provide thin bindings to OCCT.
+* Wrap all OCCT modules (if practical).
+* React quickly to new OCCT releases.
+* Cater primarily for the CadQuery project.
+
+## Non-goals
+* Provide additional functionality not present in OCCT

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -5,9 +5,10 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "cadquery-ocp"
 version = "7.8.1.1"
-description = "Unchanged OCP package, just pypi packaged"
+description = "Python wrapper for OCCT generated using pywrap."
 authors = [{ name = "Bernhard Walter", email = "b_walter@arcor.de" }]
 requires-python = ">=3.10"
+readme = "README.md"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
Added local readme for pypi and pypi-stubs and fixed some issues.

By the way -- I am not sure the pyproject.toml and readme files are properly used for the cadquery-vtk wheels. They don't seem to match what is on the cadquery-vtk pypi project page.